### PR TITLE
Log exceptions at debug level, rather than error

### DIFF
--- a/charms/contextual_status.py
+++ b/charms/contextual_status.py
@@ -101,6 +101,6 @@ def on_error(status: StatusBase, *status_exceptions: Type[Exception]):
         yield
     except status_exceptions as e:
         msg = f"Found expected exception: {e}"
-        log.error(msg)
+        log.debug(msg)
         add(status)
         raise ReconcilerError(msg) from e


### PR DESCRIPTION
Helps to filter expected exceptions to not fill the ERROR log level, but rather DEBUG.  This can be controlled via model-config